### PR TITLE
Fix `BannerLayer` typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -70,7 +70,7 @@ export interface BannerLayer {
     /**
      * Custom layer children provided as a React element, for example `<Video />`
      */
-    children: any;
+    children?: any;
     /**
      * Indicate if the layer should be expanded with negative top/bottom margins so the edges will
      * never be visible.


### PR DESCRIPTION
To prevent the following TS error to happen:

```
Property ‘children’ is missing in type ‘{ image: string; amount: number; }’ but required in type ‘BannerLayer’.
```

When providing a basic array of layers to `ParallaxBanner` component

```
<ParallaxBanner
    className="your-class"
    layers={[
        {
            image: 'https://foo.com/foo.jpg',
            amount: 0.1,
        },
        {
            image: 'https://foo.com/bar.png',
            amount: 0.2,
        },
    ]}
    style={{
        height: '500px',
    }}
>
    <h1>Banner Children</h1>
</ParallaxBanner>
```