### PR TITLE
fix: add children to parallax provider type

### DIFF
--- a/src/components/ParallaxProvider/types.ts
+++ b/src/components/ParallaxProvider/types.ts
@@ -11,4 +11,6 @@ export interface ParallaxProviderProps {
    * to the HTML body
    */
   scrollContainer?: HTMLElement;
+
+  children?: React.ReactNode;
 }


### PR DESCRIPTION
ParallaxProvider component does not accept children when props are provided.

Fixes this: https://github.com/jscottsmith/react-scroll-parallax/issues/194