### PR TITLE
fix: strict mode and missing context value

### DIFF
--- a/src/components/ParallaxProvider/ParallaxProvider.tsx
+++ b/src/components/ParallaxProvider/ParallaxProvider.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect, useRef } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 
 import { ParallaxContext } from '../../context/ParallaxContext';
 import { ScrollAxis } from 'parallax-controller';
@@ -8,41 +8,44 @@ import { createController } from './helpers';
 export function ParallaxProvider(
   props: PropsWithChildren<ParallaxProviderProps>
 ) {
-  const controller = useRef(
+  const [controller] = useState(
     createController({
       scrollAxis: props.scrollAxis || ScrollAxis.vertical,
       scrollContainer: props.scrollContainer,
       disabled: props.isDisabled,
     })
   );
-
   // update scroll container
   useEffect(() => {
-    if (props.scrollContainer && controller.current) {
-      controller.current.updateScrollContainer(props.scrollContainer);
+    if (props.scrollContainer && controller) {
+      controller.updateScrollContainer(props.scrollContainer);
     }
-  }, [props.scrollContainer, controller.current]);
+  }, [props.scrollContainer, controller]);
 
   // disable/enable parallax
   useEffect(() => {
-    if (props.isDisabled && controller.current) {
-      controller.current.disableParallaxController();
+    if (props.isDisabled && controller) {
+      controller.disableParallaxController();
     }
-    if (!props.isDisabled && controller.current) {
-      controller.current.enableParallaxController();
+    if (!props.isDisabled && controller) {
+      controller.enableParallaxController();
     }
-  }, [props.isDisabled, controller.current]);
+  }, [props.isDisabled, controller]);
 
-  // remove the controller when unmounting
+  // enable and disable parallax controller on mount/unmount
   useEffect(() => {
+    // Enable it on mount
+    if (!props.isDisabled && controller) {
+      controller && controller?.enableParallaxController();
+    }
     return () => {
-      controller?.current && controller?.current.destroy();
-      controller.current = null;
+      // Disable it on unmount
+      controller && controller?.disableParallaxController();
     };
   }, []);
 
   return (
-    <ParallaxContext.Provider value={controller.current}>
+    <ParallaxContext.Provider value={controller}>
       {props.children}
     </ParallaxContext.Provider>
   );


### PR DESCRIPTION
This PR fixes #233 #227 and #221

The issue was that the controller could become null in between renders, e.g. when React is in strict mode. Strict mode in React makes all useEffects run twice, to make sure they don't have any memory leaks, etc. More can be read here: https://legacy.reactjs.org/docs/strict-mode.html#ensuring-reusable-state

What happened is that the last useEffect that handles unmount got called twice, thus the controller became null. This is not a NextJS issue, but React Strict mode issue (strict mode with useEffect came in React 18). Because of this, the useEffect should always handle both mount & unmount (never assume that unmount gets called once).

With this PR I never make the controller null, instead I just disable the controller which should clean all the event listeners. Please correct me if I'm wrong.

I've tested these changes in NextJS app router and it seems to fix all of the issues.