### PR TITLE
fix typo in next-13.md

### DIFF
--- a/documentation/docs/usage/next-13.md
+++ b/documentation/docs/usage/next-13.md
@@ -39,7 +39,7 @@ next-app
     └── layout.tsx
 ```
 
-Your layout may differ from the one below — it's is simplified for this example.
+Your layout may differ from the one below — it is simplified for this example.
 
 ```tsx
 import { Providers } from './Providers';


### PR DESCRIPTION
Fix typo in `documentation/docs/usage/next-13.md`